### PR TITLE
fix(ci): add permissions for security audit check run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,9 @@ jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: rustsec/audit-check@v2


### PR DESCRIPTION
The rustsec/audit-check action needs `checks: write` permission to post check results.

Fixes: `Error: Resource not accessible by integration`