### PR TITLE
fix(ci): use env var for PR body to prevent shell injection

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -220,9 +220,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check PR description
+        env:
+          BODY: ${{ github.event.pull_request.body }}
         run: |
-          BODY="${{ github.event.pull_request.body }}"
-
           # Check if PR has a description
           if [ -z "$BODY" ] || [ ${#BODY} -lt 50 ]; then
             echo "::warning::PR description is missing or too short. Please describe your changes."


### PR DESCRIPTION
Fixes backticks in PR descriptions being interpreted as shell commands.