### PR TITLE
fix(deps): ignore unmaintained transitive dependency advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -90,6 +90,10 @@ ignore = [
     # rustls-pemfile is unmaintained, but comes from testcontainers -> bollard (dev-dependency only)
     # Upstream needs to migrate to rustls-pki-types
     "RUSTSEC-2025-0134",
+
+    # paste is unmaintained, but comes from iggy -> iggy_common -> compio-io
+    # Upstream (iggy/compio) needs to migrate to pastey or alternative
+    "RUSTSEC-2024-0436",
 ]
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds the unmaintained `paste` crate advisory (RUSTSEC-2024-0436) to the cargo-deny ignore list. This is a transitive dependency from the iggy SDK that we cannot directly update.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD changes

## Changes Made

- Added `RUSTSEC-2024-0436` (paste) to `deny.toml` ignore list with justification

## Dependency Analysis

### RUSTSEC-2024-0436 (paste)
```
paste v1.0.15
└── compio-io v0.8.4
    └── iggy_common v0.8.0
        └── iggy v0.8.0
            └── iggy_sample (this crate)
```

This is a transitive dependency from the iggy SDK. The upstream compio project would need to migrate to `pastey` (the maintained fork).

### RUSTSEC-2025-0134 (rustls-pemfile)
Already ignored in deny.toml. This comes from testcontainers → bollard (dev-dependency only).

## Testing

- [x] Manual testing performed

**Test commands run:**
```bash
cargo clippy -- -D warnings
cargo test --lib
```

## Checklist

### Code Quality
- [x] Code follows project style guidelines (`cargo fmt`)
- [x] No new Clippy warnings (`cargo clippy -- -D warnings`)
- [x] Public APIs have documentation comments
- [x] Error handling is appropriate (no unwrap in production code)

### Documentation
- [x] Code comments explain "why" not "what"

### Security
- [x] No secrets or credentials committed
- [x] No new security vulnerabilities introduced

## Related Issues

Closes #10
Closes #11

## Additional Notes

Both advisories are for unmaintained crates that are transitive dependencies. We cannot directly update them - the upstream projects (iggy, testcontainers/bollard) need to migrate to alternatives. Adding to the ignore list is the standard practice for such cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)